### PR TITLE
Update bundler to the latest and greatest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.7)
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -87,7 +88,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (3.12.6)
+    puma (5.2.2)
+      nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-protection (2.1.0)
@@ -146,4 +148,4 @@ DEPENDENCIES
   sinatra (~> 2.1.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.14


### PR DESCRIPTION
and update gems.

```
cf push identity-fake-server
...
          Bundle complete! 12 Gemfile dependencies, 10 gems now installed.
          Gems in the groups development and test were not installed.
          Bundled gems are installed into `/tmp/contents405955630/deps/0/vendor_bundle`
   -----> Regenerating bundler binstubs...
          **WARNING** Your Gemfile.lock was bundled with bundler 2.1.4, which is incompatible with the current bundler version (2.2.13).
          **WARNING** Deleting "Bundled With" from the Gemfile.lock
          Cleaning up the bundler cache.
```