### PR TITLE
Parse delays as floating point

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+ruby RUBY_VERSION
 source 'https://rubygems.org'
 
 gem 'sinatra', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,5 +149,8 @@ DEPENDENCIES
   rspec
   sinatra (~> 2.1.0)
 
+RUBY VERSION
+   ruby 2.7.0p0
+
 BUNDLED WITH
    2.2.14

--- a/app.rb
+++ b/app.rb
@@ -21,23 +21,23 @@ module LoginGov
 
       case action
       when 'http://schemas.xmlsoap.org/ws/2005/02/trust/RST/SCT'
-        sleep ENV['AAMVA_SECURITY_TOKEN_DELAY'].to_i
+        sleep ENV['AAMVA_SECURITY_TOKEN_DELAY'].to_f
         fixture 'aamva/security_token_response.xml'
       when 'http://aamva.org/authentication/3.1.0/IAuthenticationService/Authenticate'
-        sleep ENV['AAMVA_AUTHENTICATION_TOKEN_DELAY'].to_i
+        sleep ENV['AAMVA_AUTHENTICATION_TOKEN_DELAY'].to_f
         fixture 'aamva/authentication_token_response.xml'
       end
     end
 
     # AAMVA
     post '/dldv/2.1/online' do
-      sleep ENV['AAMVA_VERIFICATION_DELAY'].to_i
+      sleep ENV['AAMVA_VERIFICATION_DELAY'].to_f
       fixture 'aamva/verification_response.xml'
     end
 
     # Acuant
     post '/AssureIDService/Document/Instance' do
-      sleep ENV['ACUANT_CREATE_DOCUMENT_DELAY'].to_i
+      sleep ENV['ACUANT_CREATE_DOCUMENT_DELAY'].to_f
       # body is a JSON atom
       SecureRandom.hex.to_json
     end
@@ -49,20 +49,20 @@ module LoginGov
 
     # The way the Acuant Client encodes images does not play well with sinatra's parameter parsing
     error Sinatra::BadRequest do
-      sleep ENV['ACUANT_UPLOAD_IMAGE_DELAY'].to_i
+      sleep ENV['ACUANT_UPLOAD_IMAGE_DELAY'].to_f
       status 200
       ''
     end
 
     # Acuant
     post '/api/v1/facematch' do
-      sleep ENV['ACUANT_FACEMATCH_DELAY'].to_i
+      sleep ENV['ACUANT_FACEMATCH_DELAY'].to_f
       fixture 'acuant/facial_match_response.json'
     end
 
     # Acuant
     get '/AssureIDService/Document/:instance_id' do
-      sleep ENV['ACUANT_GET_RESULTS_DELAY'].to_i
+      sleep ENV['ACUANT_GET_RESULTS_DELAY'].to_f
       fixture 'acuant/get_results_response.json'
     end
 
@@ -70,10 +70,10 @@ module LoginGov
     post "/restws/identity/v2/:account_number/:workflow_name/conversation" do
       case params[:workflow_name]
       when /instant.verify/
-        sleep ENV['LEXISNEXIS_INSTANT_VERIFY_DELAY'].to_i
+        sleep ENV['LEXISNEXIS_INSTANT_VERIFY_DELAY'].to_f
         fixture 'lexisnexis/instant_verify_response.json'
       when /phonefinder/
-        sleep ENV['LEXISNEXIS_PHONE_FINDER_DELAY'].to_i
+        sleep ENV['LEXISNEXIS_PHONE_FINDER_DELAY'].to_f
         fixture 'lexisnexis/phone_finder_response.json'
       end
     end


### PR DESCRIPTION
**Why**: To allow for better precision


----

Luckily `''.to_f == 0.0`