### PR TITLE
Stop using vendor/bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,8 @@ jobs:
       - run:
           name: deploy to cloud.gov
           command: |
-            bundle package --all
+            bundle config set cache_all true
+            bundle package
             cf push identity-fake-server
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
           name: Install dependencies
           command: |
             gem install bundler
-            bundle check || bundle install --retry=3 --path vendor/bundle
+            bundle check || bundle install --retry=3
 
   build-release:
     steps:


### PR DESCRIPTION
**Why**: Fix a warning from logs during deploy


```
          **WARNING** Removing `vendor/bundle`.
          Checking in `vendor/bundle` is not supported. Please remove this directory and add it to your .gitignore. To vendor your gems with Bundler, use `bundle pack` instead.
```