### PR TITLE
Add Dockerfile so this app can be shipped in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+FROM ruby:2.7.4
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get dist-upgrade -y
+
+ENV APP_HOME /identity-fake-server
+ENV PUMA_MIN_THREADS 1
+ENV PUMA_MAX_THREADS 128
+ENV PUMA_NUM_WORKERS 2
+
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+ADD . $APP_HOME
+
+RUN gem install bundler:2.2.14
+RUN bundle install
+
+EXPOSE 5555
+CMD ["bundle", "exec", "puma", "-p", "5555", "-C", "config/puma.rb"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+services:
+  web:
+    build: .
+    command: bundle exec puma -p 5555 -C config/puma.rb
+    ports:
+      - "5555:5555"


### PR DESCRIPTION
This adds a Dockerfile to make this app more portable. The image builds fine: https://hub.docker.com/repository/docker/logindotgov/identity-fake-server/general however I have not been able to connect to it once running in the container.

It seems to load fine but I can't access anything on http://localhost:5555 or the host IP as expected

```
 % curl 192.168.1.99:5555
curl: (7) Failed to connect to 192.168.1.99 port 5555: Connection refused
```

Perhaps it's an issue with Docker on OSX. I'm going to try on a linux box.