### PR TITLE
Stub USPS routes with fixture responses

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -77,5 +77,25 @@ module LoginGov
         fixture 'lexisnexis/phone_finder_response.json'
       end
     end
+
+    # USPS
+    post '/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant' do
+      fixture 'usps/request_enroll_response.json'
+    end
+
+    # USPS
+    post '/ivs-ippaas-api/IPPRest/resources/rest/getProofingResults' do
+      fixture 'usps/request_passed_proofing_results_response.json'
+    end
+
+    # USPS
+    post '/ivs-ippaas-api/IPPRest/resources/rest/requestEnrollmentCode' do
+      fixture 'usps/request_enrollment_code_response.json'
+    end
+
+    # USPS
+    post '/oauth/authenticate' do
+      fixture 'usps/request_token_response.json'
+    end
   end
 end

--- a/fixtures/usps/request_enroll_response.json
+++ b/fixtures/usps/request_enroll_response.json
@@ -1,0 +1,4 @@
+{
+  "enrollmentCode": "2048702198804353",
+  "responseMessage": "Applicant 123456789 successfully processed"
+}

--- a/fixtures/usps/request_enrollment_code_response.json
+++ b/fixtures/usps/request_enrollment_code_response.json
@@ -1,0 +1,4 @@
+{
+  "enrollmentCode": "2048702198804358",
+  "responseMessage": "Applicant 123456789 successfully processed"
+}

--- a/fixtures/usps/request_passed_proofing_results_response.json
+++ b/fixtures/usps/request_passed_proofing_results_response.json
@@ -1,0 +1,13 @@
+{
+  "status": "In-person passed",
+  "proofingPostOffice": "WILKES BARRE",
+  "proofingCity": "WILKES BARRE",
+  "proofingState": "PA",
+  "enrollmentCode": "2090002197504352",
+  "primaryIdType": "State driver's license",
+  "transactionStartDateTime": "12/17/2020 033855",
+  "transactionEndDateTime": "12/17/2020 034055",
+  "fraudSuspected": false,
+  "proofingConfirmationNumber": "350040248346701",
+  "ippAssuranceLevel": "1.5"
+}

--- a/fixtures/usps/request_token_response.json
+++ b/fixtures/usps/request_token_response.json
@@ -1,0 +1,5 @@
+{
+  "token_type": "Bearer",
+  "access_token": "==PZWyMP2ZHGOIeTd17YomIf7XjZUL4G93dboY1pTsuTJN0s9BwMYvOcIS9B3gRvloK2sroi9uFXdXrFuly7==",
+  "expires_in": 900
+}


### PR DESCRIPTION
**Why**: In support of future load-testing efforts.

_Draft:_ These are incomplete, but I had implemented them for my own testing of in-person proofing launch preparation, and figured they may be useful for future load testing effort.

Still needs:

- [ ] Add environment variables for configurable delay
- [ ] Implement delay using `sleep` based on configuration (see other routes for prior art)
- [ ] Specs (if possible)

Fixtures sourced from IdP: https://github.com/18F/identity-idp/tree/main/app/services/usps_in_person_proofing/mock/responses

Routes based on proofer requests: https://github.com/18F/identity-idp/blob/main/app/services/usps_in_person_proofing/proofer.rb