### PR TITLE
Reduce CPU threshold of autoscaler. Format yaml indentation.

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -28,60 +28,60 @@ spec:
       labels:
         app: fake-server
       annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/path: '/metrics'
-        prometheus.io/port: '5555'
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "5555"
     spec:
       containers:
-      - name: fake-server
-        image: 894947205914.dkr.ecr.us-west-2.amazonaws.com/logindotgov/identity-fake-server:1.2.1
-        env:
-        - name: AAMVA_SECURITY_TOKEN_DELAY
-          value: "0.3645"
-        - name: AAMVA_AUTHENTICATION_TOKEN_DELAY
-          value: "0.3706"
-        - name: AAMVA_VERIFICATION_DELAY
-          value: "3.4252"
-        - name: ACUANT_CREATE_DOCUMENT_DELAY
-          value: "0.3916"
-        - name: ACUANT_UPLOAD_IMAGE_DELAY
-          value: "1.5201"
-        - name: ACUANT_FACEMATCH_DELAY
-          value: "4"
-        - name: ACUANT_GET_RESULTS_DELAY
-          value: "8.3772"
-        - name: LEXISNEXIS_INSTANT_VERIFY_DELAY
-          value: "0.9257"
-        - name: LEXISNEXIS_PHONE_FINDER_DELAY
-          value: "3.3355"
-        - name: LEXISNEXIS_TRUE_ID_DELAY
-          value: "15.0"
-        - name: USPS_IPPAAS_GETPROOFINGRESULTS_OUTCOME
-          value: "missing_enrollment_code"
-        - name: NEW_RELIC_LICENSE_KEY
-          valueFrom:
-            secretKeyRef:
-              name: newrelic-license
-              key: newrelic-license
-              optional: false
-        - name: NEW_RELIC_APP_NAME
-          value: fake-server.loadtest.identitysandbox.gov
-        - name: NEW_RELIC_HOST
-          value: gov-collector.newrelic.com
-        resources:
-          requests:
-            cpu: "75m"
-            memory: "256Mi"
-          limits:
-            cpu: "80m"
-            memory: "512Mi"
-        ports:
-        - containerPort: 5555
+        - name: fake-server
+          image: 894947205914.dkr.ecr.us-west-2.amazonaws.com/logindotgov/identity-fake-server:1.2.1
+          env:
+            - name: AAMVA_SECURITY_TOKEN_DELAY
+              value: "0.3645"
+            - name: AAMVA_AUTHENTICATION_TOKEN_DELAY
+              value: "0.3706"
+            - name: AAMVA_VERIFICATION_DELAY
+              value: "3.4252"
+            - name: ACUANT_CREATE_DOCUMENT_DELAY
+              value: "0.3916"
+            - name: ACUANT_UPLOAD_IMAGE_DELAY
+              value: "1.5201"
+            - name: ACUANT_FACEMATCH_DELAY
+              value: "4"
+            - name: ACUANT_GET_RESULTS_DELAY
+              value: "8.3772"
+            - name: LEXISNEXIS_INSTANT_VERIFY_DELAY
+              value: "0.9257"
+            - name: LEXISNEXIS_PHONE_FINDER_DELAY
+              value: "3.3355"
+            - name: LEXISNEXIS_TRUE_ID_DELAY
+              value: "15.0"
+            - name: USPS_IPPAAS_GETPROOFINGRESULTS_OUTCOME
+              value: "missing_enrollment_code"
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: newrelic-license
+                  key: newrelic-license
+                  optional: false
+            - name: NEW_RELIC_APP_NAME
+              value: fake-server.loadtest.identitysandbox.gov
+            - name: NEW_RELIC_HOST
+              value: gov-collector.newrelic.com
+          resources:
+            requests:
+              cpu: "75m"
+              memory: "256Mi"
+            limits:
+              cpu: "80m"
+              memory: "512Mi"
+          ports:
+            - containerPort: 5555
       tolerations:
-      - key: "spot"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
+        - key: "spot"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
 
 ---
 apiVersion: v1
@@ -108,14 +108,14 @@ spec:
     kind: Deployment
     name: fake-server
   minReplicas: 1
-  maxReplicas: 2000
+  maxReplicas: 2400
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 20
   # - type: Pods
   #   pods:
   #     metric:
@@ -137,8 +137,8 @@ metadata:
 spec:
   ingressClassName: alb
   tls:
-  - hosts:
-    - fake-server.loadtest.identitysandbox.gov
+    - hosts:
+        - fake-server.loadtest.identitysandbox.gov
   rules:
     - http:
         paths:


### PR DESCRIPTION
```
  36:7      error    wrong indentation: expected 8 but found 6  (indentation)
  39:9      error    wrong indentation: expected 10 but found 8  (indentation)
  79:9      error    wrong indentation: expected 10 but found 8  (indentation)
  81:7      error    wrong indentation: expected 8 but found 6  (indentation)
  113:3     error    wrong indentation: expected 4 but found 2  (indentation)
  140:3     error    wrong indentation: expected 4 but found 2  (indentation)
  141:5     error    wrong indentation: expected 6 but found 4  (indentation)
```
